### PR TITLE
Use Julia v1.11 to create docs

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.10"
+          version: "1.11"
       - uses: julia-actions/cache@v2
       - name: instantiate docs
         run: |


### PR DESCRIPTION
Pluto.jl does not support Julia v1.12 at the moment, see https://github.com/vchuravy/Ariadne.jl/actions/runs/18529344098/job/52807745138?pr=31#step:7:13. That's why the documentation CI job in https://github.com/vchuravy/Ariadne.jl/pull/31 failed.