### PR TITLE
export SplitODEProblem from Theseus.jl

### DIFF
--- a/libs/Theseus/src/Theseus.jl
+++ b/libs/Theseus/src/Theseus.jl
@@ -20,8 +20,8 @@ abstract type AbstractTimeIntegrator end
 
 using DiffEqBase: DiffEqBase
 
-import DiffEqBase: solve, CallbackSet, ODEProblem
-export solve, ODEProblem
+import DiffEqBase: solve, CallbackSet, ODEProblem, SplitODEProblem
+export solve, ODEProblem, SplitODEProblem
 
 # Interface required by DiffEqCallbacks.jl
 function DiffEqBase.get_tstops(integrator::AbstractTimeIntegrator)


### PR DESCRIPTION
This is required if one wants to define a `SplitODEProblem` (which is required for IMEX methods right now).