### PR TITLE
WIP: Add MIS method

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -12,15 +12,17 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 OrdinaryDiffEqLowStorageRK = "b0944070-b475-4768-8dec-fb6eb410534d"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SummationByPartsOperators = "9f78cca6-572e-554e-b819-917d2f1cf240"
 Theseus = "7f538e44-2768-4ef2-af90-2110c0378286"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
+TrixiAtmo = "c9ed1054-d170-44a9-8ee2-d5566f5d1389"
 
 [sources]
 Ariadne = {path = ".."}
 Theseus = {path = "../libs/Theseus"}
 
 [compat]
-Trixi = "0.13.1"
+Trixi = "0.16"
 julia = "1.10"

--- a/examples/trixi_hevi_mis_dirk_gravity_waves.jl
+++ b/examples/trixi_hevi_mis_dirk_gravity_waves.jl
@@ -1,0 +1,238 @@
+# # Using an implicit-explicit (IMEX) Runge-Kutta solver based on Ariadne with Trixi.jl
+
+using Trixi
+using TrixiAtmo
+using Theseus
+using CairoMakie
+
+# Notes:
+# You must disable both Polyester and LoopVectorization for Enzyme to be able to differentiate Trixi.jl.
+#
+# LocalPreferences.jl
+# ```toml
+# [Trixi]
+# loop_vectorization = false
+# backend = "static"
+# ```
+
+@assert Trixi._PREFERENCE_THREADING !== :polyester
+@assert !Trixi._PREFERENCE_LOOPVECTORIZATION
+
+# First call to load callbacks
+trixi_include(@__MODULE__, joinpath(TrixiAtmo.examples_dir(), "euler/dry_air/buoyancy", "elixir_potential_temperature_inertia_gravity_waves.jl"), sol = nothing);
+
+
+# The standard Trixi.jl implementation of the slip wall boundary condition is not directly 
+# compatible with this general splitting approach, since it is based on Toro's Riemann solver 
+# which always returns boundary condition values for the entire right-hand side. 
+# This function computes the boundary condition based on the surface flux function of the 
+# explicit and implicit parts, where the splitting has been defined and thus accounts for it.
+@inline function boundary_condition_slip_wall_simple(u_inner,
+                                                     normal_direction::AbstractVector,
+                                                     x, t,
+                                                     surface_flux_function,
+                                                     equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # normalize the outward pointing direction
+    normal = normal_direction / Trixi.norm(normal_direction)
+
+    # compute the normal momentum from
+    # u = (rho, rho v1, rho v2, rho e)
+    u_normal = normal[1] * u_inner[2] + normal[2] * u_inner[3]
+
+    # create the "external" boundary solution state
+    u_boundary = SVector(u_inner[1],
+                         u_inner[2] - 2 * u_normal * normal[1],
+                         u_inner[3] - 2 * u_normal * normal[2],
+			 u_inner[4], u_inner[5])
+
+    # calculate the boundary flux
+    flux, _ = surface_flux_function(u_inner, u_boundary, normal_direction, equations)
+
+    return flux
+end
+
+# The total flux is split into:
+# - Fast (implicit/stiff) part: Contains all pressure-related terms responsible for acoustic waves.
+#   Uses LMARS for surface fluxes and Kennedy-Gruber for volume fluxes.
+# - Slow (explicit/non-stiff) part: Contains convective terms (advection).
+@inline function flux_lmars_fast(u_ll, u_rr, normal_direction::AbstractVector,
+                                 equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # Reference speed of sound
+    a = 340
+    # Unpack left and right state
+    rho_ll, v1_ll, v2_ll, p_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, p_rr = cons2prim(u_rr, equations)
+
+    v_ll = v1_ll * normal_direction[1] + v2_ll * normal_direction[2]
+    v_rr = v1_rr * normal_direction[1] + v2_rr * normal_direction[2]
+    v_ll_vert = v2_ll * normal_direction[2]
+    v_rr_vert = v2_rr * normal_direction[2]
+
+    norm_ = Trixi.norm(normal_direction)
+
+    rho = 0.5f0 * (rho_ll + rho_rr)
+
+    p_interface = 0.5f0 * (p_ll + p_rr) - 0.5f0 * a * rho * (v_rr - v_ll) / norm_
+    v_interface = 0.5f0 * (v_ll + v_rr) - 1 / (2 * a * rho) * (p_rr - p_ll) * norm_
+    v_interface_vert = 0.5f0 * (v_ll_vert + v_rr_vert) - 1 / (2 * a * rho) * (p_rr - p_ll) * norm_
+
+    if (v_interface_vert > 0)
+	f1 = u_ll[1] * v_interface_vert
+	f4 = u_ll[4] * v_interface_vert
+    else
+	f1 = u_rr[1] * v_interface_vert
+	f4 = u_rr[4] * v_interface_vert
+    end
+
+    flux = SVector(f1,
+		   zero(eltype(u_ll)),
+                   p_interface * normal_direction[2],
+		   f4, zero(eltype(u_ll)))
+    return flux, flux
+end
+
+ @inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_lmars_fast),
+    equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D) = Trixi.True()
+
+
+@inline function flux_lmars_slow(u_ll, u_rr, normal_direction::AbstractVector,
+                                 equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # Reference speed of sound
+    a = 340
+    # Unpack left and right state
+    rho_ll, v1_ll, v2_ll, p_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, p_rr = cons2prim(u_rr, equations)
+
+    v_ll = v1_ll * normal_direction[1] + v2_ll * normal_direction[2]
+    v_rr = v1_rr * normal_direction[1] + v2_rr * normal_direction[2]
+
+    v_ll_hor = v1_ll * normal_direction[1]
+    v_rr_hor = v1_rr * normal_direction[1]
+
+    norm_ = Trixi.norm(normal_direction)
+
+    rho = 0.5f0 * (rho_ll + rho_rr)
+
+    p_interface = 0.5f0 * (p_ll + p_rr) - 0.5f0 * a * rho * (v_rr - v_ll) / norm_
+    v_interface = 0.5f0 * (v_ll + v_rr) - 1 / (2 * a * rho) * (p_rr - p_ll) * norm_
+    v_interface_hor = 0.5f0 * (v_ll_hor + v_rr_hor)# - 1 / (2 * a * rho) * (p_rr - p_ll) * norm_
+
+    if (v_interface > 0)
+	f2 = u_ll[2] * v_interface
+	f3 = u_ll[3] * v_interface
+    else
+	f2 = u_rr[2] * v_interface
+	f3 = u_rr[3] * v_interface
+    end
+    if (v_interface_hor > 0)
+	f1 = u_ll[1] * v_interface_hor
+	f4 = u_ll[4] * v_interface_hor
+    else
+	f1 = u_rr[1] * v_interface_hor
+	f4 = u_rr[4] * v_interface_hor
+    end
+    f2 = f2 + p_interface * normal_direction[1]
+    flux = SVector(f1, f2, f3, f4, zero(eltype(u_ll)))
+    return flux, flux
+end
+ @inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_lmars_slow),
+    equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D) = Trixi.True()
+
+@inline function flux_kennedy_gruber_slow(u_ll, u_rr, normal_direction::AbstractVector,
+                                          equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # Unpack left and right state
+    rho_ll, v1_ll, v2_ll, p_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, p_rr = cons2prim(u_rr, equations)
+
+    # Average each factor of products in flux
+    rho_avg = 0.5f0 * (rho_ll + rho_rr)
+    v1_avg = 0.5f0 * (v1_ll + v1_rr)
+    v2_avg = 0.5f0 * (v2_ll + v2_rr)
+    v_dot_n_avg_hor = v1_avg * normal_direction[1]
+    v_dot_n_avg = v1_avg * normal_direction[1] + v2_avg * normal_direction[2]
+    p_avg = 0.5f0 * (p_ll + p_rr)
+    rho_theta_ll = u_ll[4]
+    rho_theta_rr = u_rr[4]
+    rho_theta_avg = 0.5f0 * (rho_theta_ll+rho_theta_rr)
+
+    # Calculate fluxes depending on normal_direction
+    f1 = rho_avg * v_dot_n_avg_hor
+    f2 = rho_avg * v_dot_n_avg * v1_avg + p_avg * normal_direction[1]
+    f3 = rho_avg * v_dot_n_avg * v2_avg
+    f4 = rho_theta_avg * v_dot_n_avg_hor
+    flux = SVector(f1, f2, f3, f4, zero(eltype(u_ll)))
+    return flux, flux 
+end
+
+ @inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_kennedy_gruber_slow),
+    equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D) = Trixi.True()
+@inline function flux_kennedy_gruber_fast(u_ll, u_rr, normal_direction::AbstractVector,
+                                          equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # Unpack left and right state
+    rho_ll, v1_ll, v2_ll, p_ll, phi_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, p_rr, phi_rr = cons2prim(u_rr, equations)
+
+    # Average each factor of products in flux
+    rho_avg = 0.5f0 * (rho_rr + rho_ll)
+    v1_avg = 0.5f0 * (v1_ll + v1_rr)
+    v2_avg = 0.5f0 * (v2_ll + v2_rr)
+    v_dot_n_avg = v2_avg * normal_direction[2]
+    p_avg = 0.5f0 * (p_ll + p_rr)
+    rho_theta_ll = u_ll[4]
+    rho_theta_rr = u_rr[4]
+    rho_theta_avg = 0.5f0 * (rho_theta_ll+rho_theta_rr)
+    # Calculate fluxes depending on normal_direction
+    f1 = rho_avg * v_dot_n_avg
+    f2 = zero(eltype(u_ll))
+    f3 = p_avg * normal_direction[2]
+    f4 = rho_theta_avg * v_dot_n_avg
+
+    gravity = rho_avg * (phi_rr - phi_ll)
+    g2 = gravity * normal_direction[1]
+    g3 = gravity * normal_direction[2] 
+
+    return SVector(f1, f2 + 0.5f0 * g2, f3 + 0.5f0 * g3, f4, zero(eltype(u_ll))),
+    SVector(f1, f2 - 0.5f0 * g2, f3 - 0.5f0 * g3, f4, zero(eltype(u_ll)))
+end
+
+ @inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_kennedy_gruber_fast),
+    equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D) = Trixi.True()
+volume_integral_nonstiff = VolumeIntegralFluxDifferencing(flux_kennedy_gruber_slow)
+solver_nonstiff = DGSEM(polydeg = polydeg, surface_flux = flux_lmars_slow, volume_integral = volume_integral_nonstiff)
+
+volume_integral_stiff = VolumeIntegralFluxDifferencing(flux_kennedy_gruber_fast)
+solver_stiff = DGSEM(polydeg = polydeg, surface_flux =flux_lmars_fast, volume_integral = volume_integral_stiff)
+
+boundary_conditions = (;
+                       y_neg = boundary_condition_slip_wall_simple,
+                       y_pos = boundary_condition_slip_wall_simple)
+
+initial_condition = initial_condition_gravity_waves
+
+coordinates_min = (0.0, 0.0)
+coordinates_max = (300_000.0, 10_000.0)
+trees_per_dimension = (60, 8)
+mesh = P4estMesh(trees_per_dimension; polydeg = polydeg,
+                 coordinates_min = coordinates_min, coordinates_max = coordinates_max,
+                 periodicity = (true, false), initial_refinement_level = 0)
+
+semi = SemidiscretizationHyperbolicSplit(mesh,
+                                         (equations, equations),
+                                         initial_condition,
+                                         (solver_stiff, solver_nonstiff);
+                                         boundary_conditions = (boundary_conditions,
+                                                                boundary_conditions))
+
+alive_callback = AliveCallback(analysis_interval = 100)
+cfl = 2.0
+trixi_include(@__MODULE__, joinpath(TrixiAtmo.examples_dir(), "euler/dry_air/buoyancy", "elixir_potential_temperature_inertia_gravity_waves.jl"), sol = nothing, semi = semi, mesh = mesh, alive_callback = alive_callback, cfl = cfl);
+###############################################################################
+# run the simulation
+
+sol = solve(
+    ode,
+    (Theseus.MISRK3(), Theseus.DIRK43());
+    dt = 1.0, dt_fast = 0.01,# solve needs some value here but it will be overwritten by the stepsize_callback
+    ode_default_options()..., callback = callbacks,
+    krylov_algo = :gmres,
+);

--- a/examples/trixi_hevi_mis_ssp_gravity_waves.jl
+++ b/examples/trixi_hevi_mis_ssp_gravity_waves.jl
@@ -1,0 +1,239 @@
+# # Using an implicit-explicit (IMEX) Runge-Kutta solver based on Ariadne with Trixi.jl
+
+using Trixi
+using TrixiAtmo
+using Theseus
+using OrdinaryDiffEqSSPRK
+using CairoMakie
+
+# Notes:
+# You must disable both Polyester and LoopVectorization for Enzyme to be able to differentiate Trixi.jl.
+#
+# LocalPreferences.jl
+# ```toml
+# [Trixi]
+# loop_vectorization = false
+# backend = "static"
+# ```
+
+@assert Trixi._PREFERENCE_THREADING !== :polyester
+@assert !Trixi._PREFERENCE_LOOPVECTORIZATION
+
+# First call to load callbacks
+trixi_include(@__MODULE__, joinpath(TrixiAtmo.examples_dir(), "euler/dry_air/buoyancy", "elixir_potential_temperature_inertia_gravity_waves.jl"), sol = nothing);
+
+
+# The standard Trixi.jl implementation of the slip wall boundary condition is not directly 
+# compatible with this general splitting approach, since it is based on Toro's Riemann solver 
+# which always returns boundary condition values for the entire right-hand side. 
+# This function computes the boundary condition based on the surface flux function of the 
+# explicit and implicit parts, where the splitting has been defined and thus accounts for it.
+@inline function boundary_condition_slip_wall_simple(u_inner,
+                                                     normal_direction::AbstractVector,
+                                                     x, t,
+                                                     surface_flux_function,
+                                                     equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # normalize the outward pointing direction
+    normal = normal_direction / Trixi.norm(normal_direction)
+
+    # compute the normal momentum from
+    # u = (rho, rho v1, rho v2, rho e)
+    u_normal = normal[1] * u_inner[2] + normal[2] * u_inner[3]
+
+    # create the "external" boundary solution state
+    u_boundary = SVector(u_inner[1],
+                         u_inner[2] - 2 * u_normal * normal[1],
+                         u_inner[3] - 2 * u_normal * normal[2],
+			 u_inner[4], u_inner[5])
+
+    # calculate the boundary flux
+    flux, _ = surface_flux_function(u_inner, u_boundary, normal_direction, equations)
+
+    return flux
+end
+
+# The total flux is split into:
+# - Fast (implicit/stiff) part: Contains all pressure-related terms responsible for acoustic waves.
+#   Uses LMARS for surface fluxes and Kennedy-Gruber for volume fluxes.
+# - Slow (explicit/non-stiff) part: Contains convective terms (advection).
+@inline function flux_lmars_fast(u_ll, u_rr, normal_direction::AbstractVector,
+                                 equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # Reference speed of sound
+    a = 340
+    # Unpack left and right state
+    rho_ll, v1_ll, v2_ll, p_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, p_rr = cons2prim(u_rr, equations)
+
+    v_ll = v1_ll * normal_direction[1] + v2_ll * normal_direction[2]
+    v_rr = v1_rr * normal_direction[1] + v2_rr * normal_direction[2]
+    v_ll_vert = v2_ll * normal_direction[2]
+    v_rr_vert = v2_rr * normal_direction[2]
+
+    norm_ = Trixi.norm(normal_direction)
+
+    rho = 0.5f0 * (rho_ll + rho_rr)
+
+    p_interface = 0.5f0 * (p_ll + p_rr) - 0.5f0 * a * rho * (v_rr - v_ll) / norm_
+    v_interface = 0.5f0 * (v_ll + v_rr) - 1 / (2 * a * rho) * (p_rr - p_ll) * norm_
+    v_interface_vert = 0.5f0 * (v_ll_vert + v_rr_vert) - 1 / (2 * a * rho) * (p_rr - p_ll) * norm_
+
+    if (v_interface_vert > 0)
+	f1 = u_ll[1] * v_interface_vert
+	f4 = u_ll[4] * v_interface_vert
+    else
+	f1 = u_rr[1] * v_interface_vert
+	f4 = u_rr[4] * v_interface_vert
+    end
+
+    flux = SVector(f1,
+		   zero(eltype(u_ll)),
+                   p_interface * normal_direction[2],
+		   f4, zero(eltype(u_ll)))
+    return flux, flux
+end
+
+ @inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_lmars_fast),
+    equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D) = Trixi.True()
+
+
+@inline function flux_lmars_slow(u_ll, u_rr, normal_direction::AbstractVector,
+                                 equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # Reference speed of sound
+    a = 340
+    # Unpack left and right state
+    rho_ll, v1_ll, v2_ll, p_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, p_rr = cons2prim(u_rr, equations)
+
+    v_ll = v1_ll * normal_direction[1] + v2_ll * normal_direction[2]
+    v_rr = v1_rr * normal_direction[1] + v2_rr * normal_direction[2]
+
+    v_ll_hor = v1_ll * normal_direction[1]
+    v_rr_hor = v1_rr * normal_direction[1]
+
+    norm_ = Trixi.norm(normal_direction)
+
+    rho = 0.5f0 * (rho_ll + rho_rr)
+
+    p_interface = 0.5f0 * (p_ll + p_rr) - 0.5f0 * a * rho * (v_rr - v_ll) / norm_
+    v_interface = 0.5f0 * (v_ll + v_rr) - 1 / (2 * a * rho) * (p_rr - p_ll) * norm_
+    v_interface_hor = 0.5f0 * (v_ll_hor + v_rr_hor)# - 1 / (2 * a * rho) * (p_rr - p_ll) * norm_
+
+    if (v_interface > 0)
+	f2 = u_ll[2] * v_interface
+	f3 = u_ll[3] * v_interface
+    else
+	f2 = u_rr[2] * v_interface
+	f3 = u_rr[3] * v_interface
+    end
+    if (v_interface_hor > 0)
+	f1 = u_ll[1] * v_interface_hor
+	f4 = u_ll[4] * v_interface_hor
+    else
+	f1 = u_rr[1] * v_interface_hor
+	f4 = u_rr[4] * v_interface_hor
+    end
+    f2 = f2 + p_interface * normal_direction[1]
+    flux = SVector(f1, f2, f3, f4, zero(eltype(u_ll)))
+    return flux, flux
+end
+ @inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_lmars_slow),
+    equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D) = Trixi.True()
+
+@inline function flux_kennedy_gruber_slow(u_ll, u_rr, normal_direction::AbstractVector,
+                                          equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # Unpack left and right state
+    rho_ll, v1_ll, v2_ll, p_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, p_rr = cons2prim(u_rr, equations)
+
+    # Average each factor of products in flux
+    rho_avg = 0.5f0 * (rho_ll + rho_rr)
+    v1_avg = 0.5f0 * (v1_ll + v1_rr)
+    v2_avg = 0.5f0 * (v2_ll + v2_rr)
+    v_dot_n_avg_hor = v1_avg * normal_direction[1]
+    v_dot_n_avg = v1_avg * normal_direction[1] + v2_avg * normal_direction[2]
+    p_avg = 0.5f0 * (p_ll + p_rr)
+    rho_theta_ll = u_ll[4]
+    rho_theta_rr = u_rr[4]
+    rho_theta_avg = 0.5f0 * (rho_theta_ll+rho_theta_rr)
+
+    # Calculate fluxes depending on normal_direction
+    f1 = rho_avg * v_dot_n_avg_hor
+    f2 = rho_avg * v_dot_n_avg * v1_avg + p_avg * normal_direction[1]
+    f3 = rho_avg * v_dot_n_avg * v2_avg
+    f4 = rho_theta_avg * v_dot_n_avg_hor
+    flux = SVector(f1, f2, f3, f4, zero(eltype(u_ll)))
+    return flux, flux 
+end
+
+ @inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_kennedy_gruber_slow),
+    equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D) = Trixi.True()
+@inline function flux_kennedy_gruber_fast(u_ll, u_rr, normal_direction::AbstractVector,
+                                          equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D)
+    # Unpack left and right state
+    rho_ll, v1_ll, v2_ll, p_ll, phi_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, p_rr, phi_rr = cons2prim(u_rr, equations)
+
+    # Average each factor of products in flux
+    rho_avg = 0.5f0 * (rho_rr + rho_ll)
+    v1_avg = 0.5f0 * (v1_ll + v1_rr)
+    v2_avg = 0.5f0 * (v2_ll + v2_rr)
+    v_dot_n_avg = v2_avg * normal_direction[2]
+    p_avg = 0.5f0 * (p_ll + p_rr)
+    rho_theta_ll = u_ll[4]
+    rho_theta_rr = u_rr[4]
+    rho_theta_avg = 0.5f0 * (rho_theta_ll+rho_theta_rr)
+    # Calculate fluxes depending on normal_direction
+    f1 = rho_avg * v_dot_n_avg
+    f2 = zero(eltype(u_ll))
+    f3 = p_avg * normal_direction[2]
+    f4 = rho_theta_avg * v_dot_n_avg
+
+    gravity = rho_avg * (phi_rr - phi_ll)
+    g2 = gravity * normal_direction[1]
+    g3 = gravity * normal_direction[2] 
+
+    return SVector(f1, f2 + 0.5f0 * g2, f3 + 0.5f0 * g3, f4, zero(eltype(u_ll))),
+    SVector(f1, f2 - 0.5f0 * g2, f3 - 0.5f0 * g3, f4, zero(eltype(u_ll)))
+end
+
+ @inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_kennedy_gruber_fast),
+    equations::CompressibleEulerPotentialTemperatureEquationsWithGravity2D) = Trixi.True()
+volume_integral_nonstiff = VolumeIntegralFluxDifferencing(flux_kennedy_gruber_slow)
+solver_nonstiff = DGSEM(polydeg = polydeg, surface_flux = flux_lmars_slow, volume_integral = volume_integral_nonstiff)
+
+volume_integral_stiff = VolumeIntegralFluxDifferencing(flux_kennedy_gruber_fast)
+solver_stiff = DGSEM(polydeg = polydeg, surface_flux =flux_lmars_fast, volume_integral = volume_integral_stiff)
+
+boundary_conditions = (;
+                       y_neg = boundary_condition_slip_wall_simple,
+                       y_pos = boundary_condition_slip_wall_simple)
+
+initial_condition = initial_condition_gravity_waves
+
+coordinates_min = (0.0, 0.0)
+coordinates_max = (300_000.0, 10_000.0)
+trees_per_dimension = (60, 8)
+mesh = P4estMesh(trees_per_dimension; polydeg = polydeg,
+                 coordinates_min = coordinates_min, coordinates_max = coordinates_max,
+                 periodicity = (true, false), initial_refinement_level = 0)
+
+semi = SemidiscretizationHyperbolicSplit(mesh,
+                                         (equations, equations),
+                                         initial_condition,
+                                         (solver_stiff, solver_nonstiff);
+                                         boundary_conditions = (boundary_conditions,
+                                                                boundary_conditions))
+
+alive_callback = AliveCallback(analysis_interval = 10000)
+stepsize_callback = nothing
+cfl = 3.0
+trixi_include(@__MODULE__, joinpath(TrixiAtmo.examples_dir(), "euler/dry_air/buoyancy", "elixir_potential_temperature_inertia_gravity_waves.jl"), sol = nothing, semi = semi, mesh = mesh, alive_callback = alive_callback, stepsize_callback = stepsize_callback);
+###############################################################################
+# run the simulation
+
+sol = solve(
+    ode,
+    (Theseus.MISRK3(), SSPRK43());
+    dt = 3.0, dt_fast = 0.78,# solve needs some value here but it will be overwritten by the stepsize_callback
+    ode_default_options()..., callback = callbacks, adaptive = false,
+);

--- a/libs/Theseus/src/Theseus.jl
+++ b/libs/Theseus/src/Theseus.jl
@@ -414,4 +414,5 @@ end
 include("rosenbrock/rosenbrock.jl")
 include("imex/imex.jl")
 include("dirk/dirk.jl")
+include("mis/mis.jl")
 end # module Theseus

--- a/libs/Theseus/src/Theseus.jl
+++ b/libs/Theseus/src/Theseus.jl
@@ -50,7 +50,20 @@ end
 import SciMLBase: get_du, get_tmp_cache, u_modified!,
     init, step!, check_error,
     get_proposed_dt, set_proposed_dt!,
-    terminate!, remake, add_tstop!, has_tstop, first_tstop
+    terminate!, remake, add_tstop!, has_tstop, first_tstop, reinit!
+
+
+function reinit!(integrator::AbstractTimeIntegrator,
+                 u0 = integrator.sol.prob.u0;
+                 t0 = first(integrator.sol.prob.tspan),
+                 tf = last(integrator.sol.prob.tspan),
+                 kwargs...)
+    integrator.u .= u0
+    integrator.t = t0
+    integrator.iter = 0
+    integrator.finalstep = false
+    integrator.sol = (prob = remake(integrator.sol.prob; tspan = (t0, tf)),)
+end
 
 
 # Abstract base type for time integration schemes

--- a/libs/Theseus/src/mis/mis.jl
+++ b/libs/Theseus/src/mis/mis.jl
@@ -13,19 +13,19 @@ function (::MISSlowAlgorithm{N})(un, Δt, fslow!, Zn0, dZn, Yn, du, p, t, stages
 	
     @. Zn0 = un
 
-    @trixi_timeit timer() "init MIS" compute_initial_condition!(Zn0, Yn, un, RK.alfa, stage)
+        compute_initial_condition!(Zn0, Yn, un, RK.alfa, stage)
 	
     	o = zero(eltype(un))
 	@. dZn = o
-	@trixi_timeit timer() "setting ODE MIS"	compute_slow_tendencies!(dZn, Yn, stages, un, RK.d, RK.gamma, RK.beta, invdt, stage)
+	compute_slow_tendencies!(dZn, Yn, stages, un, RK.d, RK.gamma, RK.beta, invdt, stage)
 	
 	if stage == 1
-		@. Yn[stage] = un
+	@. Yn[stage] = un
 	else
-	     @trixi_timeit timer() "solve fast ODE" solve_fastode!(integrator_fast.alg, integrator_fast, Zn0, dZn, Yn, stage, RK.d[stage] * Δt, dt_fast)
+	solve_fastode!(integrator_fast.alg, integrator_fast, Zn0, dZn, Yn, stage, RK.d[stage] * Δt, dt_fast)
 	end
 		
-	@trixi_timeit timer() "slow tendencies" fslow!(du, Yn[stage], p, t + Δt)
+	fslow!(du, Yn[stage], p, t + Δt)
 	stages[stage] .= du
 end
 
@@ -65,7 +65,7 @@ mutable struct MISOptions{Callback, TStops}
 end
 
 function MISOptions(callback, tspan; maxiters = typemax(Int), verbose = 0, kwargs...)
-    tstops_internal = BinaryHeap{eltype(tspan)}(FasterForward())
+        tstops_internal = eltype(tspan)[]
     # We add last(tspan) to make sure that the time integration stops at the end time
     push!(tstops_internal, last(tspan))
     # We add 2 * last(tspan) because add_tstop!(integrator, t) is only called by DiffEqCallbacks.jl if tstops contains a time that is larger than t
@@ -84,7 +84,7 @@ end
 # which are used in Trixi.jl.
 mutable struct MISSlow{RealT <: Real, uType, Params, Sol, F, M,
                           Alg <: MISSlowAlgorithm,
-                          MISOptions, RKTableau, Thread, IntegratorType} <:
+                          MISOptions, RKTableau, IntegratorType, WorkspaceType} <:
                AbstractTimeIntegrator
     u::uType
     du::uType
@@ -107,12 +107,12 @@ mutable struct MISSlow{RealT <: Real, uType, Params, Sol, F, M,
     RK::RKTableau
     const dtchangeable::Bool
     const force_stepfail::Bool
-    thread::Thread
     integrator_fast::IntegratorType
     dt_fast::RealT
+    workspace::WorkspaceType
 end
 
-function init(ode::SplitODEProblem, alg::Tuple{MISSlowAlgorithm{N},FastAlg};
+function init(ode::ODEProblem, alg::Tuple{MISSlowAlgorithm{N},FastAlg};
               dt, callback::Union{CallbackSet, Nothing} = nothing,
 	      dt_fast, kwargs...,) where {N, FastAlg}
     u = copy(ode.u0)
@@ -129,11 +129,12 @@ function init(ode::SplitODEProblem, alg::Tuple{MISSlowAlgorithm{N},FastAlg};
 
 alg_slow = alg[1]
 alg_fast = alg[2]
-integrator = (; dZn) 
 
+integrator = (; dZn) 
+workspace= nothing
 integrator_fast = let
     corrected_ffast! = (du, u, p, t) -> begin
-        ode.f.f1!(du, u, p, t)
+        ode.f.f1(du, u, p, t)
         du .+= integrator.dZn
     end
 
@@ -144,7 +145,7 @@ end
                             (prob = ode,), ode.f.f2, alg_slow,
                             MISOptions(callback, ode.tspan;
                                               kwargs...,), false, RKTableau(alg_slow, eltype(u)),
-                            false, false, thread, integrator_fast, dt_fast)
+                            false, false, integrator_fast, dt_fast, workspace)
     # initialize callbacks
     if callback isa CallbackSet
         foreach(callback.continuous_callbacks) do cb
@@ -159,7 +160,7 @@ end
 end
 
 # Fakes `solve`: https://diffeq.sciml.ai/v6.8/basics/overview/#Solving-the-Problems-1
-function solve(ode::SplitODEProblem,alg::Tuple{<:MISSlowAlgorithm,Any};
+function solve(ode::ODEProblem, alg::Tuple{<:MISSlowAlgorithm, Any};
                dt, callback = nothing, 
                kwargs...,)
     integrator = init(ode, alg, dt = dt, callback = callback; kwargs...)
@@ -187,14 +188,10 @@ end
 function stage!(integrator, alg::MISSlowAlgorithm)
 
     for stage in 1:stages(alg)
-        @trixi_timeit timer() "slow time integration" alg(integrator.u, integrator.dt,
-                                               integrator.f, integrator.Zn0, integrator.dZn, integrator.Yn, integrator.du,
-                                               integrator.p, integrator.t,
-                                               integrator.stages, stage, integrator.RK,
-                                               integrator.integrator_fast, integrator.dt_fast)
+        alg(integrator.u, integrator.dt, integrator.f, integrator.Zn0, integrator.dZn, integrator.Yn, integrator.du, integrator.p, integrator.t, integrator.stages, stage, integrator.RK, integrator.integrator_fast, integrator.dt_fast)
     end
 
- @. integrator.u_tmp = integrator.Yn[end]
+    @. integrator.u_tmp = integrator.Yn[end]
 
     return
 end

--- a/libs/Theseus/src/mis/mis.jl
+++ b/libs/Theseus/src/mis/mis.jl
@@ -1,0 +1,290 @@
+abstract type MISAlgorithm{N} end
+abstract type MISSlowAlgorithm{N} <: MISAlgorithm{N} end
+abstract type MISFastAlgorithm{N} <: MISAlgorithm{N} end
+
+stages(::MISAlgorithm{N}) where {N} = N
+
+"""
+	(::MISAlgorithm{N})(res, uₙ, Δt, f!, du, u, p, t, stages, stage, workspace, RK, assume_p_const) where N
+
+"""
+@muladd begin
+function (::MISSlowAlgorithm{N})(un, Δt, fslow!, Zn0, dZn, Yn, du, p, t, stages, stage, RK, integrator_fast, dt_fast) where {N}
+    invdt = inv(Δt)
+	
+    @. Zn0 = un
+
+    @trixi_timeit timer() "init MIS" compute_initial_condition!(Zn0, Yn, un, RK.alfa, stage)
+	
+    	o = zero(eltype(un))
+	@. dZn = o
+	@trixi_timeit timer() "setting ODE MIS"	compute_slow_tendencies!(dZn, Yn, stages, un, RK.d, RK.gamma, RK.beta, invdt, stage)
+	
+	if stage == 1
+		@. Yn[stage] = un
+	else
+	     @trixi_timeit timer() "solve fast ODE" solve_fastode!(integrator_fast.alg, integrator_fast, Zn0, dZn, Yn, stage, RK.d[stage] * Δt, dt_fast)
+	end
+		
+	@trixi_timeit timer() "slow tendencies" fslow!(du, Yn[stage], p, t + Δt)
+	stages[stage] .= du
+end
+end
+
+function solve_fastode!(alg, integrator_fast, Zn0, dZn, Yn, stage, T, dt)
+    reinit!(integrator_fast, Zn0; t0 = zero(eltype(Zn0)), tf = T)
+    integrator_fast.dt = dt
+    while integrator_fast.t < T
+    step!(integrator_fast)
+    end
+
+    @. Yn[stage] = integrator_fast.u
+end
+
+ function compute_initial_condition!(Zn0, Yn, u, alfa, stage)
+        for j in 1:(stage - 1)
+		alfa_stage = alfa[stage,j]
+     @. Zn0 = Zn0 + alfa_stage * (Yn[j] - u)
+        end
+    end
+    
+    function compute_slow_tendencies!(dZn, Yn, du, u, d, gamma, beta, invdt, stage)
+        for j in 1:(stage - 1)
+		gamma_j = gamma[stage,j]
+		beta_j = beta[stage,j]
+		inv_d_j = inv(d[stage])
+      @. dZn = dZn + inv_d_j * (invdt * gamma_j * (Yn[j] - u) + beta_j * du[j])
+        end
+    end
+
+mutable struct MISOptions{Callback, TStops}
+    callback::Callback # callbacks; used in Trixi.jl
+    adaptive::Bool # whether the algorithm is adaptive; ignored
+    dtmax::Float64 # ignored
+    maxiters::Int # maximal number of time steps
+    verbose::Int
+    tstops::TStops # tstops from https://diffeq.sciml.ai/v6.8/basics/common_solver_opts/#Output-Control-1; ignored
+end
+
+function MISOptions(callback, tspan; maxiters = typemax(Int), verbose = 0, kwargs...)
+    tstops_internal = BinaryHeap{eltype(tspan)}(FasterForward())
+    # We add last(tspan) to make sure that the time integration stops at the end time
+    push!(tstops_internal, last(tspan))
+    # We add 2 * last(tspan) because add_tstop!(integrator, t) is only called by DiffEqCallbacks.jl if tstops contains a time that is larger than t
+    # (https://github.com/SciML/DiffEqCallbacks.jl/blob/025dfe99029bd0f30a2e027582744528eb92cd24/src/iterative_and_periodic.jl#L92)
+    push!(tstops_internal, 2 * last(tspan))
+    return MISOptions{typeof(callback), typeof(tstops_internal)}(callback, false,
+                                                                        Inf, maxiters,
+                                                                        verbose,
+                                                                        tstops_internal)
+end
+
+
+# This struct is needed to fake https://github.com/SciML/OrdinaryDiffEq.jl/blob/0c2048a502101647ac35faabd80da8a5645beac7/src/integrators/type.jl#L77
+# This implements the interface components described at
+# https://diffeq.sciml.ai/v6.8/basics/integrator/#Handing-Integrators-1
+# which are used in Trixi.jl.
+mutable struct MISSlow{RealT <: Real, uType, Params, Sol, F, M,
+                          Alg <: MISSlowAlgorithm,
+                          MISOptions, RKTableau, Thread, IntegratorType} <:
+               AbstractTimeIntegrator
+    u::uType
+    du::uType
+    u_tmp::uType
+    stages::NTuple{M, uType}
+    Zn0::uType
+    dZn::uType
+    Yn::NTuple{M, uType}
+    t::RealT
+    tdir::RealT # DIRection of time integration, i.e., if one marches forward or backward in time
+    dt::RealT # current time step
+    dtcache::RealT # ignored
+    iter::Int # current number of time steps (iteration)
+    p::Params # will be the semidiscretization from Trixi.jl
+    sol::Sol # faked
+    f::F # `rhs!` of the semidiscretization
+    alg::Alg # MISAlgorithm
+    opts::MISOptions
+    finalstep::Bool # added for convenience
+    RK::RKTableau
+    const dtchangeable::Bool
+    const force_stepfail::Bool
+    thread::Thread
+    integrator_fast::IntegratorType
+    dt_fast::RealT
+end
+
+function init(ode::SplitODEProblem, alg::Tuple{MISSlowAlgorithm{N},FastAlg};
+              dt, callback::Union{CallbackSet, Nothing} = nothing,
+	      dt_fast, kwargs...,) where {N, FastAlg}
+    u = copy(ode.u0)
+    du = zero(u)
+    u_tmp = similar(u)
+    Zn0 = similar(u)
+    dZn = similar(u)
+    u_tmp = similar(u)
+    stages = ntuple(_ -> similar(u), Val(N))
+    Yn = ntuple(_ -> similar(u), Val(N))
+    t = first(ode.tspan)
+    iter = 0
+    tdir = sign(ode.tspan[end] - ode.tspan[1])
+
+alg_slow = alg[1]
+alg_fast = alg[2]
+integrator = (; dZn) 
+
+integrator_fast = let
+    corrected_ffast! = (du, u, p, t) -> begin
+        ode.f.f1!(du, u, p, t)
+        du .+= integrator.dZn
+    end
+
+    prob_fast = ODEProblem(corrected_ffast!, copy(u), (0.0, 1.0), ode.p)
+    init(prob_fast, alg_fast; dt = dt_fast, kwargs...)
+end
+    integrator = MISSlow(u, du, u_tmp, stages, Zn0, dZn, Yn, t, tdir, dt, zero(dt), iter, ode.p,
+                            (prob = ode,), ode.f.f2, alg_slow,
+                            MISOptions(callback, ode.tspan;
+                                              kwargs...,), false, RKTableau(alg_slow, eltype(u)),
+                            false, false, thread, integrator_fast, dt_fast)
+    # initialize callbacks
+    if callback isa CallbackSet
+        foreach(callback.continuous_callbacks) do cb
+            throw(ArgumentError("Continuous callbacks are unsupported with the implicit time integration methods."))
+        end
+        foreach(callback.discrete_callbacks) do cb
+            cb.initialize(cb, integrator.u, integrator.t, integrator)
+        end
+    end
+
+    return integrator
+end
+
+# Fakes `solve`: https://diffeq.sciml.ai/v6.8/basics/overview/#Solving-the-Problems-1
+function solve(ode::SplitODEProblem,alg::Tuple{<:MISSlowAlgorithm,Any};
+               dt, callback = nothing, 
+               kwargs...,)
+    integrator = init(ode, alg, dt = dt, callback = callback; kwargs...)
+
+    # Start actual solve
+    return solve!(integrator)
+end
+
+function solve!(integrator::MISSlow)
+    @unpack prob = integrator.sol
+
+    integrator.finalstep = false
+
+    while !integrator.finalstep
+        step!(integrator)
+    end # "main loop" timer
+
+    finalize_callbacks(integrator)
+
+    return TimeIntegratorSolution((first(prob.tspan), integrator.t),
+                                  (prob.u0, integrator.u),
+                                  integrator.sol.prob)
+end
+
+function stage!(integrator, alg::MISSlowAlgorithm)
+
+    for stage in 1:stages(alg)
+        @trixi_timeit timer() "slow time integration" alg(integrator.u, integrator.dt,
+                                               integrator.f, integrator.Zn0, integrator.dZn, integrator.Yn, integrator.du,
+                                               integrator.p, integrator.t,
+                                               integrator.stages, stage, integrator.RK,
+                                               integrator.integrator_fast, integrator.dt_fast)
+    end
+
+ @. integrator.u_tmp = integrator.Yn[end]
+
+    return
+end
+
+function step!(integrator::MISSlow)
+    @unpack prob = integrator.sol
+    @unpack alg = integrator
+    t_end = last(prob.tspan)
+    callbacks = integrator.opts.callback
+
+    @assert !integrator.finalstep
+    if isnan(integrator.dt)
+        error("time step size `dt` is NaN")
+    end
+
+    # if the next iteration would push the simulation beyond the end time, set dt accordingly
+    if integrator.t + integrator.dt > t_end ||
+       isapprox(integrator.t + integrator.dt, t_end)
+        integrator.dt = t_end - integrator.t
+        terminate!(integrator)
+    end
+
+    # one time step
+    integrator.u_tmp .= integrator.u
+
+    stage!(integrator, alg)
+
+    integrator.u .= integrator.u_tmp
+
+    integrator.iter += 1
+    integrator.t += integrator.dt
+
+    begin
+        # handle callbacks
+        if callbacks isa CallbackSet
+            foreach(callbacks.discrete_callbacks) do cb
+                if cb.condition(integrator.u, integrator.t, integrator)
+                    cb.affect!(integrator)
+                end
+                return nothing
+            end
+        end
+    end
+
+    # respect maximum number of iterations
+    return if integrator.iter >= integrator.opts.maxiters && !integrator.finalstep
+        @warn "Interrupted. Larger maxiters is needed."
+        terminate!(integrator)
+    end
+end
+
+# Forward integrator.stats.naccept to integrator.iter (see GitHub PR#771)
+function Base.getproperty(integrator::MISSlow, field::Symbol)
+    if field === :stats
+        return (naccept = getfield(integrator, :iter),)
+    end
+    # general fallback
+    return getfield(integrator, field)
+end
+
+# get a cache where the RHS can be stored
+get_du(integrator::MISSlow) = integrator.du
+get_tmp_cache(integrator::MISSlow) = (integrator.u_tmp,)
+
+# some algorithms from DiffEq like FSAL-ones need to be informed when a callback has modified u
+u_modified!(integrator::MISSlow, ::Bool) = false
+
+# used by adaptive timestepping algorithms in DiffEq
+function set_proposed_dt!(integrator::MISSlow, dt)
+    return integrator.dt = dt
+end
+
+# Required e.g. for `glm_speed_callback`
+function get_proposed_dt(integrator::MISSlow)
+    return integrator.dt
+end
+
+# stop the time integration
+function terminate!(integrator::MISSlow)
+    integrator.finalstep = true
+    return empty!(integrator.opts.tstops)
+end
+
+# used for AMR
+function Base.resize!(integrator::MISSlow, new_size)
+    resize!(integrator.u, new_size)
+    resize!(integrator.du, new_size)
+    return resize!(integrator.u_tmp, new_size)
+end
+
+include("tableau.jl")

--- a/libs/Theseus/src/mis/mis.jl
+++ b/libs/Theseus/src/mis/mis.jl
@@ -8,7 +8,6 @@ stages(::MISAlgorithm{N}) where {N} = N
 	(::MISAlgorithm{N})(res, uₙ, Δt, f!, du, u, p, t, stages, stage, workspace, RK, assume_p_const) where N
 
 """
-@muladd begin
 function (::MISSlowAlgorithm{N})(un, Δt, fslow!, Zn0, dZn, Yn, du, p, t, stages, stage, RK, integrator_fast, dt_fast) where {N}
     invdt = inv(Δt)
 	
@@ -28,7 +27,6 @@ function (::MISSlowAlgorithm{N})(un, Δt, fslow!, Zn0, dZn, Yn, du, p, t, stages
 		
 	@trixi_timeit timer() "slow tendencies" fslow!(du, Yn[stage], p, t + Δt)
 	stages[stage] .= du
-end
 end
 
 function solve_fastode!(alg, integrator_fast, Zn0, dZn, Yn, stage, T, dt)

--- a/libs/Theseus/src/mis/tableau.jl
+++ b/libs/Theseus/src/mis/tableau.jl
@@ -1,0 +1,134 @@
+struct MISRK{T1<:AbstractArray, T2<:AbstractArray} <: RKTableau
+ beta::T1
+	alfa::T1
+	gamma::T1
+	d::T2
+end
+
+struct MISRK3 <: MISSlowAlgorithm{4} end
+
+function RKTableau(alg::MISRK3, RealT)
+    rkstages = 4
+    beta = zeros(RealT, rkstages, rkstages)
+    alfa = zeros(RealT, rkstages, rkstages)
+    gamma = zeros(RealT, rkstages, rkstages)
+    d = zeros(RealT, rkstages, 1)
+    beta[2, 1] = 1/3
+    beta[3, 2] = 1/2
+    beta[4, 3] = 1
+    d[2] = 1/3
+    d[3] = 1/2
+    d[4] = 1
+    d = SVector(0.0, d[2], d[3], d[4])
+
+    return MISRK(beta, alfa, gamma, d)
+end
+
+
+struct MISRK4 <: MISSlowAlgorithm{5} end
+
+function RKTableau(alg::MISRK4, RealT)
+            rkstages = 5
+            beta = zeros(RealT, rkstages, rkstages)
+            alfa = zeros(RealT, rkstages, rkstages)
+            gamma = zeros(RealT, rkstages, rkstages)
+            d = zeros(RealT, rkstages, 1)
+            beta[2, 1] = 0.38758444641450318
+            beta[3, 1] = -2.5318448354142823E-002
+            beta[3, 2] = 0.38668943087310403
+            beta[4, 1] = 0.20899983523553325
+            beta[4, 2] = -0.45856648476371231
+            beta[4, 3] = 0.43423187573425748
+            beta[5, 1] = -0.10048822195663100
+            beta[5, 2] = -0.46186171956333327
+            beta[5, 3] = 0.83045062122462809
+            beta[5, 4] = 0.27014914900250392
+    
+            alfa[3, 2] = 0.52349249922385610
+            alfa[4, 2] = 1.1683374366893629
+            alfa[4, 3] = -0.75762080241712637
+            alfa[5, 2] = -3.6477233846797109E-002
+            alfa[5, 3] = 0.56936148730740477
+            alfa[5, 4] = 0.47746263002599681
+    
+            gamma[3, 2] = 0.13145089796226542
+            gamma[4, 2] = -0.36855857648747881
+            gamma[4, 3] = 0.33159232636600550
+            gamma[5, 2] = -6.5767130537473045E-002
+            gamma[5, 3] = 4.0591093109036858E-002
+            gamma[5, 4] = 6.4902111640806712E-002
+    
+            d2 = beta[2, 1]
+            d3 = beta[3, 1] + beta[3, 2]
+            d4 = beta[4, 1] + beta[4, 2] + beta[4, 3]
+            d5 = beta[5, 1] + beta[5, 2] + beta[5, 3] + beta[5, 4]
+	    d = SVector(0, d2, d3, d4, d5)
+
+	return MISRK(beta, alfa, gamma, d)
+end
+
+struct MIS2 <: MISSlowAlgorithm{3} end
+
+function RKTableau(alg::MIS2, RealT)
+    rkstages = 4
+    beta  = zeros(RealT, rkstages, rkstages)
+    alfa  = zeros(RealT, rkstages, rkstages)
+    gamma = zeros(RealT, rkstages, rkstages)
+    d     = zeros(RealT, rkstages, 1)
+
+    # β coefficients
+    beta[2, 1] =  0.126848494553
+    beta[3, 1] = -0.784838278826
+    beta[3, 2] =  1.37442675268
+    beta[4, 1] = -0.0456727081749
+    beta[4, 2] = -0.00875082271190
+    beta[4, 3] =  0.524775788629
+
+    # α coefficients
+    alfa[3, 2] =  0.536946566710
+    alfa[4, 2] =  0.480892968551
+    alfa[4, 3] =  0.500561163566
+
+    # γ coefficients
+    gamma[3, 2] =  0.652465126004
+    gamma[4, 2] = -0.0732769849457
+    gamma[4, 3] =  0.144902430420
+
+    d2 = beta[2, 1]
+    d3 = beta[3, 1] + beta[3, 2]
+    d4 = beta[4, 1] + beta[4, 2] + beta[4, 3]
+    d  = SVector(0, d2, d3, d4)
+
+    return MISRK(beta, alfa, gamma, d)
+end
+
+struct JEB3 <: MISSlowAlgorithm{4} end
+
+function RKTableau(alg::JEB3, RealT)
+rkstages = 4
+    beta = zeros(RealT, rkstages, rkstages)
+    alpha = zeros(RealT, rkstages, rkstages)
+    gamma = zeros(RealT, rkstages, rkstages)
+    d = zeros(RealT, rkstages)
+
+    beta[2,1] = 2.0492941060709863e-001
+    beta[3,1] = -4.5477553356788974e-001
+    beta[3,2] = 9.5613538239378981e-001
+    beta[4,1] = -3.5970281266252929e-002
+    beta[4,2] = -1.5363649484946584e-001
+    beta[4,3] = 7.0259062712330234e-001
+
+    gamma[3,2] = -8.2176071248067006e-001
+    gamma[4,2] = -3.8080670922635063e-001
+    gamma[4,3] = 4.5653105107801978e-001
+
+    alpha[3,2] = 7.0302371060435331e-001
+    alpha[4,2] = 4.2492220536139252e-001
+    alpha[4,3] = 5.4545718243573982e-001
+
+    d[2] = beta[2, 1]
+    d[3] = beta[3, 1] + beta[3, 2]
+    d[4] = beta[4, 1] + beta[4, 2] + beta[4, 3]
+    d = SVector(0, d[2], d[3], d[4])
+	return MISRK(beta, alpha, gamma, d)
+end 

--- a/libs/Theseus/src/mis/tableau.jl
+++ b/libs/Theseus/src/mis/tableau.jl
@@ -1,5 +1,5 @@
 struct MISRK{T1<:AbstractArray, T2<:AbstractArray} <: RKTableau
- beta::T1
+        beta::T1
 	alfa::T1
 	gamma::T1
 	d::T2
@@ -19,116 +19,6 @@ function RKTableau(alg::MISRK3, RealT)
     d[2] = 1/3
     d[3] = 1/2
     d[4] = 1
-    d = SVector(0.0, d[2], d[3], d[4])
 
     return MISRK(beta, alfa, gamma, d)
 end
-
-
-struct MISRK4 <: MISSlowAlgorithm{5} end
-
-function RKTableau(alg::MISRK4, RealT)
-            rkstages = 5
-            beta = zeros(RealT, rkstages, rkstages)
-            alfa = zeros(RealT, rkstages, rkstages)
-            gamma = zeros(RealT, rkstages, rkstages)
-            d = zeros(RealT, rkstages, 1)
-            beta[2, 1] = 0.38758444641450318
-            beta[3, 1] = -2.5318448354142823E-002
-            beta[3, 2] = 0.38668943087310403
-            beta[4, 1] = 0.20899983523553325
-            beta[4, 2] = -0.45856648476371231
-            beta[4, 3] = 0.43423187573425748
-            beta[5, 1] = -0.10048822195663100
-            beta[5, 2] = -0.46186171956333327
-            beta[5, 3] = 0.83045062122462809
-            beta[5, 4] = 0.27014914900250392
-    
-            alfa[3, 2] = 0.52349249922385610
-            alfa[4, 2] = 1.1683374366893629
-            alfa[4, 3] = -0.75762080241712637
-            alfa[5, 2] = -3.6477233846797109E-002
-            alfa[5, 3] = 0.56936148730740477
-            alfa[5, 4] = 0.47746263002599681
-    
-            gamma[3, 2] = 0.13145089796226542
-            gamma[4, 2] = -0.36855857648747881
-            gamma[4, 3] = 0.33159232636600550
-            gamma[5, 2] = -6.5767130537473045E-002
-            gamma[5, 3] = 4.0591093109036858E-002
-            gamma[5, 4] = 6.4902111640806712E-002
-    
-            d2 = beta[2, 1]
-            d3 = beta[3, 1] + beta[3, 2]
-            d4 = beta[4, 1] + beta[4, 2] + beta[4, 3]
-            d5 = beta[5, 1] + beta[5, 2] + beta[5, 3] + beta[5, 4]
-	    d = SVector(0, d2, d3, d4, d5)
-
-	return MISRK(beta, alfa, gamma, d)
-end
-
-struct MIS2 <: MISSlowAlgorithm{3} end
-
-function RKTableau(alg::MIS2, RealT)
-    rkstages = 4
-    beta  = zeros(RealT, rkstages, rkstages)
-    alfa  = zeros(RealT, rkstages, rkstages)
-    gamma = zeros(RealT, rkstages, rkstages)
-    d     = zeros(RealT, rkstages, 1)
-
-    # β coefficients
-    beta[2, 1] =  0.126848494553
-    beta[3, 1] = -0.784838278826
-    beta[3, 2] =  1.37442675268
-    beta[4, 1] = -0.0456727081749
-    beta[4, 2] = -0.00875082271190
-    beta[4, 3] =  0.524775788629
-
-    # α coefficients
-    alfa[3, 2] =  0.536946566710
-    alfa[4, 2] =  0.480892968551
-    alfa[4, 3] =  0.500561163566
-
-    # γ coefficients
-    gamma[3, 2] =  0.652465126004
-    gamma[4, 2] = -0.0732769849457
-    gamma[4, 3] =  0.144902430420
-
-    d2 = beta[2, 1]
-    d3 = beta[3, 1] + beta[3, 2]
-    d4 = beta[4, 1] + beta[4, 2] + beta[4, 3]
-    d  = SVector(0, d2, d3, d4)
-
-    return MISRK(beta, alfa, gamma, d)
-end
-
-struct JEB3 <: MISSlowAlgorithm{4} end
-
-function RKTableau(alg::JEB3, RealT)
-rkstages = 4
-    beta = zeros(RealT, rkstages, rkstages)
-    alpha = zeros(RealT, rkstages, rkstages)
-    gamma = zeros(RealT, rkstages, rkstages)
-    d = zeros(RealT, rkstages)
-
-    beta[2,1] = 2.0492941060709863e-001
-    beta[3,1] = -4.5477553356788974e-001
-    beta[3,2] = 9.5613538239378981e-001
-    beta[4,1] = -3.5970281266252929e-002
-    beta[4,2] = -1.5363649484946584e-001
-    beta[4,3] = 7.0259062712330234e-001
-
-    gamma[3,2] = -8.2176071248067006e-001
-    gamma[4,2] = -3.8080670922635063e-001
-    gamma[4,3] = 4.5653105107801978e-001
-
-    alpha[3,2] = 7.0302371060435331e-001
-    alpha[4,2] = 4.2492220536139252e-001
-    alpha[4,3] = 5.4545718243573982e-001
-
-    d[2] = beta[2, 1]
-    d[3] = beta[3, 1] + beta[3, 2]
-    d[4] = beta[4, 1] + beta[4, 2] + beta[4, 3]
-    d = SVector(0, d[2], d[3], d[4])
-	return MISRK(beta, alpha, gamma, d)
-end 


### PR DESCRIPTION
This PR adds the generalized MIS method as in [https://doi.org/10.1175/MWR-D-13-00068.1](https://doi.org/10.1175/MWR-D-13-00068.1). The slow part is computed through an explicit tableau (at the moment three methods are defined, MISRK3 which is equivalent to the Skamarock and Klemp, MISRK4 defined in the above link and  RK3 from [https://doi.org/10.1175/2008MWR2671.1](https://doi.org/10.1175/2008MWR2671.1). 

The substepping (fast part) is computed with any of the methods we have in Theseus.jl (this should also be compatible with most of the methods defined in OrdinaryDiffEq.jl).

Still draft, I have to test few things in this environment and add a test case.


- [x] Compatibility with OrdinaryDiffEq
- [ ] Compatibility with Theseus